### PR TITLE
Add missing include

### DIFF
--- a/include/bitset.hpp
+++ b/include/bitset.hpp
@@ -33,6 +33,7 @@
 
 #include <bit>
 #include <cassert>
+#include <climits>
 #include <functional>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Add missing include to fix build on gcc-10 and clang-12

Issue: #1 